### PR TITLE
feat(hackney): allow self signed certificates

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -46,3 +46,10 @@ config :instream, Instream.TestHelpers.QueryAuthConnection,
 config :instream, Instream.TestHelpers.UnreachableConnection,
   hosts: [ "some.really.unreachable.host" ],
   pool:  [ max_overflow: 0, size: 1 ]
+
+
+config :instream, Instream.TestHelpers.ConnectionWithOpts,
+  auth:  [ username: "instream_test", password: "instream_test" ],
+  hosts: [ "localhost" ],
+  pool:  [ max_overflow: 0, size: 1 ],
+  http_opts: [ proxy: "http://invalidproxy" ]

--- a/lib/instream/connection/query_runner.ex
+++ b/lib/instream/connection/query_runner.ex
@@ -17,7 +17,7 @@ defmodule Instream.Connection.QueryRunner do
 
     conn
     |> URL.ping(query.opts[:host])
-    |> :hackney.head(headers)
+    |> :hackney.head(headers, "", Keyword.get(conn, :http_opts, []))
     |> Response.parse_ping()
   end
 
@@ -34,7 +34,9 @@ defmodule Instream.Connection.QueryRunner do
       |> URL.append_epoch(query.opts[:precision])
       |> URL.append_query(query.payload)
 
-    { :ok, status, headers, client } = :hackney.get(url, headers)
+    http_opts = Keyword.get(conn, :http_opts, [])
+
+    { :ok, status, headers, client } = :hackney.get(url, headers, "", http_opts)
     { :ok, response }                = :hackney.body(client)
 
     { status, headers, response } |> Response.maybe_parse(opts)
@@ -49,7 +51,7 @@ defmodule Instream.Connection.QueryRunner do
 
     conn
     |> URL.status(query.opts[:host])
-    |> :hackney.head(headers)
+    |> :hackney.head(headers, "", Keyword.get(conn, :http_opts, []))
     |> Response.parse_status()
   end
 

--- a/lib/instream/writer/json.ex
+++ b/lib/instream/writer/json.ex
@@ -17,7 +17,9 @@ defmodule Instream.Writer.JSON do
       |> URL.write()
       |> URL.append_database(opts[:database])
 
-    { :ok, status, headers, client } = :hackney.post(url, headers, payload)
+    http_opts = Keyword.get(conn, :http_opts, [])
+
+    { :ok, status, headers, client } = :hackney.post(url, headers, payload, http_opts)
     { :ok, response }                = :hackney.body(client)
 
     { status, headers, response }

--- a/lib/instream/writer/line.ex
+++ b/lib/instream/writer/line.ex
@@ -21,7 +21,9 @@ defmodule Instream.Writer.Line do
       |> URL.append_database(db)
       |> URL.append_precision(query.opts[:precision])
 
-    { :ok, status, headers, client } = :hackney.post(url, headers, body)
+    http_opts = Keyword.get(conn, :http_opts, [])
+
+    { :ok, status, headers, client } = :hackney.post(url, headers, body, http_opts)
     { :ok, response }                = :hackney.body(client)
 
     { status, headers, response }

--- a/test/helpers/connection_with_opts.exs
+++ b/test/helpers/connection_with_opts.exs
@@ -1,0 +1,3 @@
+defmodule Instream.TestHelpers.ConnectionWithOpts do
+  use Instream.Connection, otp_app: :instream
+end

--- a/test/instream/connection_test.exs
+++ b/test/instream/connection_test.exs
@@ -4,6 +4,7 @@ defmodule Instream.ConnectionTest do
   alias Instream.Query.Builder
 
   alias Instream.TestHelpers.Connection
+  alias Instream.TestHelpers.ConnectionWithOpts
   alias Instream.TestHelpers.GuestConnection
   alias Instream.TestHelpers.UnreachableConnection
 
@@ -30,11 +31,13 @@ defmodule Instream.ConnectionTest do
   test "ping connection" do
     assert :pong  == Connection.ping()
     assert :error == UnreachableConnection.ping()
+    assert :error == ConnectionWithOpts.ping()
   end
 
   test "status connection" do
     assert :ok    == Connection.status()
     assert :error == UnreachableConnection.status()
+    assert :error == ConnectionWithOpts.ping()
   end
 
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 Code.require_file("helpers/connection.exs", __DIR__)
+Code.require_file("helpers/connection_with_opts.exs", __DIR__)
 Code.require_file("helpers/json_connection.exs", __DIR__)
 Code.require_file("helpers/udp_connection.exs", __DIR__)
 
@@ -16,6 +17,7 @@ alias Instream.TestHelpers
 
 [
   TestHelpers.Connection.child_spec,
+  TestHelpers.ConnectionWithOpts.child_spec,
   TestHelpers.JSONConnection.child_spec,
   TestHelpers.UDPConnection.child_spec,
 


### PR DESCRIPTION
hackney allows the insecure[1] setting to be used:

 > insecure: to perform "insecure" SSL connections and transfers without
 > checking the certificate

This setting is now set to true every time a hackney request is executed.

[1] https://hexdocs.pm/hackney/hackney.html#request-5