### PR TITLE
Adds limit and offset support for select query

### DIFF
--- a/lib/instream/encoder/influxql.ex
+++ b/lib/instream/encoder/influxql.ex
@@ -22,6 +22,8 @@ defmodule Instream.Encoder.InfluxQL do
     |> append_binary(encode_select(get_argument(query, :select)))
     |> append_from(get_argument(query, :from))
     |> append_where(get_argument(query, :where))
+    |> append_limit(get_argument(query, :limit))
+    |> append_offset(get_argument(query, :offset))
   end
 
   def encode(%Builder{ command: "SHOW" } = query) do
@@ -146,6 +148,12 @@ defmodule Instream.Encoder.InfluxQL do
 
     str <> " WHERE " <> where
   end
+
+  defp append_limit(str, nil),   do: str
+  defp append_limit(str, value), do: "#{str} LIMIT #{value}"
+
+  defp append_offset(str, nil),   do: str
+  defp append_offset(str, value), do: "#{str} OFFSET #{value}"
 
   defp encode_select(select) when is_binary(select), do: select
   defp encode_select(select) when is_list(select)    do

--- a/lib/instream/query/builder.ex
+++ b/lib/instream/query/builder.ex
@@ -148,6 +148,17 @@ defmodule Instream.Query.Builder do
   @spec where(t, map) :: t
   def where(query, fields), do: set_argument(query, :where, fields)
 
+  @doc """
+  Builds a `LIMIT` query expression.
+  """
+  @spec limit(t, integer) :: t
+  def limit(query, value), do: set_argument(query, :limit, value)
+
+  @doc """
+  Builds a `OFFSET` query expression.
+  """
+  @spec offset(t, integer) :: t
+  def offset(query, value), do: set_argument(query, :offset, value)
 
   # Internal methods
 

--- a/test/instream/query/builder_test.exs
+++ b/test/instream/query/builder_test.exs
@@ -96,6 +96,36 @@ defmodule Instream.Query.BuilderTest do
     assert query == "SELECT * FROM some_measurement WHERE binary = 'value' AND numeric = 42"
   end
 
+  test "SELECT * WHERE foo = bar LIMIT x" do
+    fields = %{ binary: "value", numeric: 42 }
+    limit = 10
+    query  =
+         BuilderSeries
+      |> Builder.from()
+      |> Builder.select()
+      |> Builder.where(fields)
+      |> Builder.limit(limit)
+      |> InfluxQL.encode()
+
+    assert query == "SELECT * FROM some_measurement WHERE binary = 'value' AND numeric = 42 LIMIT 10"
+  end
+
+  test "SELECT * WHERE foo = bar LIMIT x OFFSET y" do
+    fields = %{ binary: "value", numeric: 42 }
+    limit = 10
+    offset = 25
+    query  =
+         BuilderSeries
+      |> Builder.from()
+      |> Builder.select()
+      |> Builder.where(fields)
+      |> Builder.limit(limit)
+      |> Builder.offset(offset)
+      |> InfluxQL.encode()
+
+    assert query == "SELECT * FROM some_measurement WHERE binary = 'value' AND numeric = 42 LIMIT 10 OFFSET 25"
+  end
+
   test "SELECT Enum.t" do
     query =
          BuilderSeries


### PR DESCRIPTION
Now we can query with offset and limit
```
# SELECT * FROM some_measurement WHERE binary = 'foo' LIMIT 15 OFFSET 78
from("some_measurement")
|> where(%{ binary: "foo"})
|> limit(15)
|> offset(78)
|> MyApp.MyConnection.query()
```