### PR TITLE
Allow retention policy to be specified for write

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,14 @@ data
 |> MyApp.MyConnection.write([ async: true, precision: :second ])
 ```
 
+If you want to specify the target retention policy name for the write, you can do so like this:
+
+```elixir
+data
+|> MyApp.MyConnection.write(retention_policy: "two_weeks")
+```
+
+
 Supported precision types are:
 
 - `:hour`

--- a/lib/instream/query/url.ex
+++ b/lib/instream/query/url.ex
@@ -50,6 +50,13 @@ defmodule Instream.Query.URL do
   end
 
   @doc """
+  Appends a retention policy to a URL.
+  """
+  @spec append_retention_policy(String.t, String.t) :: String.t
+  def append_retention_policy(url, nil),      do: url
+  def append_retention_policy(url, retention_policy_name), do: url |> append_param("rp", retention_policy_name)
+
+  @doc """
   Appends a query to an URL.
   """
   @spec append_query(String.t, String.t) :: String.t

--- a/lib/instream/writer/line.ex
+++ b/lib/instream/writer/line.ex
@@ -20,6 +20,7 @@ defmodule Instream.Writer.Line do
       |> URL.write()
       |> URL.append_database(opts[:database] || config[:database])
       |> URL.append_precision(query.opts[:precision])
+      |> URL.append_retention_policy(query.opts[:retention_policy])
 
     http_opts = Keyword.merge(Keyword.get(config, :http_opts, []),
                               Keyword.get(opts, :http_opts, []))


### PR DESCRIPTION
According to the InfluxDB docs, when writing, the retention policy can
be specified with a URL parameter named `rp`:

https://docs.influxdata.com/influxdb/v1.2/guides/writing_data/#writing-data-using-the-http-api

I was thinking that perhaps the retention policy name could be specified
in the Series definition.  Then multiple points could be written, each
of which could have its own retention policy. In communicating with
Influx support, I heard back this:

"There is currently no way to specify the database or retention policy
directly in the point at this time. Although a per-point retention
policy option is already a proposed feature for the next version of the
line protocol format."

So, we can specify the retention policy name as an option to the `write`
function alongside other options like `precision`.