### PR TITLE
Encoding '&' in influx query url to be handled by influx

### DIFF
--- a/lib/instream/query/url.ex
+++ b/lib/instream/query/url.ex
@@ -118,7 +118,13 @@ defmodule Instream.Query.URL do
         false -> "?"
       end
 
-    "#{url}#{glue}#{key}=#{URI.encode(value)}"
+    encoded_value =
+      case String.contains?(url, "&") do
+        true -> "#{URI.encode_www_form(value)}"
+        false -> "#{URI.encode(value)}"
+      end
+
+    "#{url}#{glue}#{key}=#{encoded_value}"
   end
 
   defp url(config, endpoint) do

--- a/lib/instream/query/url.ex
+++ b/lib/instream/query/url.ex
@@ -118,13 +118,9 @@ defmodule Instream.Query.URL do
         false -> "?"
       end
 
-    encoded_value =
-      case String.contains?(url, "&") do
-        true -> "#{URI.encode_www_form(value)}"
-        false -> "#{URI.encode(value)}"
-      end
+    param = URI.encode_query([{key, value}])
 
-    "#{url}#{glue}#{key}=#{encoded_value}"
+    "#{url}#{glue}#{param}"
   end
 
   defp url(config, endpoint) do

--- a/test/instream/query/url_test.exs
+++ b/test/instream/query/url_test.exs
@@ -37,14 +37,14 @@ defmodule Instream.Query.URLTest do
   end
 
   test "append query" do
-    query = "SHOW DATABASES"
+    query = ~s(SELECT "value" FROM "foo&bar?baz")
     url = "http://localhost/query"
-    expected = "#{url}?q=#{URI.encode(query)}"
+    expected = "#{url}?q=SELECT+%22value%22+FROM+%22foo%26bar%3Fbaz%22"
 
     assert expected == URL.append_query(url, query)
 
     url = "#{url}?foo=bar"
-    expected = "#{url}&q=#{URI.encode(query)}"
+    expected = "#{url}&q=SELECT+%22value%22+FROM+%22foo%26bar%3Fbaz%22"
 
     assert expected == URL.append_query(url, query)
   end


### PR DESCRIPTION
When having '&' in influx query no result was returned for which encoding need to be encode_www_form