### PR TITLE
Support lists as tag value

### DIFF
--- a/lib/instream/encoder/line.ex
+++ b/lib/instream/encoder/line.ex
@@ -77,9 +77,30 @@ defmodule Instream.Encoder.Line do
   defp encode_value(false), do: "false"
   defp encode_value(other), do: inspect(other)
 
+  defp encode_property([a | _] = atoms) when is_atom(a) do
+    atoms
+    |> Enum.map(&Atom.to_string/1)
+    |> escape()
+    |> Enum.join(",")
+  end
+
+  defp encode_property(l) when is_list(l) do
+    l
+    |> Enum.map(&Kernel.to_string/1)
+    |> escape()
+    |> Enum.join(",")
+  end
+
   defp encode_property(s) do
     s
     |> Kernel.to_string()
+    |> escape()
+  end
+
+  defp escape(l) when is_list(l), do: Enum.map(l, &escape/1)
+
+  defp escape(s) when is_binary(s) do
+    s
     |> String.replace(",", "\\,", global: true)
     |> String.replace(" ", "\\ ", global: true)
     |> String.replace("=", "\\=", global: true)

--- a/test/instream/encoder/line_test.exs
+++ b/test/instream/encoder/line_test.exs
@@ -207,4 +207,42 @@ defmodule Instream.Encoder.LineTest do
 
     assert expected == Line.encode(points)
   end
+
+  test "with list of strings in tag value" do
+    expected = ~S|disk_free,items=string_a,string_b value=442221834240i|
+
+    points = [
+      %{
+        measurement: "disk_free",
+        tags: %{
+          items: ["string_a", "string_b"]
+        },
+        fields: %{
+          value: 442_221_834_240
+        },
+        timestamp: nil
+      }
+    ]
+
+    assert expected == Line.encode(points)
+  end
+
+  test "with list of atoms in tag value" do
+    expected = ~S|disk_free,items=atom_a,atom_b value=442221834240i|
+
+    points = [
+      %{
+        measurement: "disk_free",
+        tags: %{
+          items: [:atom_a, :atom_b]
+        },
+        fields: %{
+          value: 442_221_834_240
+        },
+        timestamp: nil
+      }
+    ]
+
+    assert expected == Line.encode(points)
+  end
 end


### PR DESCRIPTION
This PR adds support to set an atom list as a value for a series tag.