### PR TITLE
Handle empty response csv parsing case

### DIFF
--- a/lib/instream/decoder/csv.ex
+++ b/lib/instream/decoder/csv.ex
@@ -51,6 +51,9 @@ defmodule Instream.Decoder.CSV do
 
   defp parse_datatypes({{field, _}, value}), do: {field, value}
 
+
+  defp parse_rows(%{table: [[""]]}), do: []
+
   defp parse_rows(%{
          datatypes: [_ | _] = datatypes,
          defaults: defaults,

--- a/lib/instream/decoder/csv.ex
+++ b/lib/instream/decoder/csv.ex
@@ -51,7 +51,6 @@ defmodule Instream.Decoder.CSV do
 
   defp parse_datatypes({{field, _}, value}), do: {field, value}
 
-
   defp parse_rows(%{table: [[""]]}), do: []
 
   defp parse_rows(%{

--- a/test/instream/decoder/csv_test.exs
+++ b/test/instream/decoder/csv_test.exs
@@ -274,5 +274,11 @@ defmodule Instream.Decoder.LineTest do
                ]
              ] = CSV.parse(response)
     end
+
+    test "emtpy response" do
+      response = "\r\n"
+
+      assert [] = CSV.parse(response)
+    end
   end
 end


### PR DESCRIPTION
If there is no rows in influxdb it responds with "\r\n". Currently parser blows up on that case, this mr fixes that.