### PR TITLE
Fix error of parsing empty string with number types

### DIFF
--- a/lib/instream/decoder/csv.ex
+++ b/lib/instream/decoder/csv.ex
@@ -43,7 +43,9 @@ defmodule Instream.Decoder.CSV do
 
   defp parse_datatypes({{field, "boolean"}, "false"}), do: {field, false}
   defp parse_datatypes({{field, "boolean"}, "true"}), do: {field, true}
+  defp parse_datatypes({{field, "double"}, ""}), do: {field, 0.0}
   defp parse_datatypes({{field, "double"}, value}), do: {field, String.to_float(value)}
+  defp parse_datatypes({{field, "long"}, ""}), do: {field, 0}
   defp parse_datatypes({{field, "long"}, value}), do: {field, String.to_integer(value)}
 
   defp parse_datatypes({{field, "dateTime:RFC3339"}, value}),


### PR DESCRIPTION
Fix error below.

```
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a textual representation of an integer

    :erlang.binary_to_integer("")
    (instream 2.0.0-dev) lib/instream/decoder/csv.ex:47: Instream.Decoder.CSV.parse_datatypes/1
    (elixir 1.12.1) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.12.1) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
    (instream 2.0.0-dev) lib/instream/decoder/csv.ex:63: anonymous fn/4 in Instream.Decoder.CSV.parse_rows/1
    (elixir 1.12.1) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
    (instream 2.0.0-dev) lib/instream/connection/query_runner_v2.ex:32: Instream.Connection.QueryRunnerV2.read/3
    (elixir 1.12.1) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.12.1) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
    (momenti_ecto 0.1.0) lib/momenti_ecto/v4/contexts/analytics/stat/conversion.ex:42: MomentiEcto.V4.Analytics.Stat.Conversion.get_data_frame/3
    (momenti_ecto 0.1.0) lib/momenti_ecto/v4/contexts/analytics/stat/conversion.ex:19: MomentiEcto.V4.Analytics.Stat.Conversion.get/3
```