### PR TITLE
Fix parsing double type without decimal point

### DIFF
--- a/lib/instream/decoder/csv.ex
+++ b/lib/instream/decoder/csv.ex
@@ -55,7 +55,7 @@ defmodule Instream.Decoder.CSV do
   defp parse_datatypes({{field, "boolean"}, _}), do: {field, false}
   defp parse_datatypes({{field, "double"}, "+Inf"}), do: {field, :infinity}
   defp parse_datatypes({{field, "double"}, "-Inf"}), do: {field, :neg_infinity}
-  defp parse_datatypes({{field, "double"}, value}), do: {field, String.to_float(value)}
+  defp parse_datatypes({{field, "double"}, value}), do: {field, Float.parse(value) |> elem(0)}
   defp parse_datatypes({{field, "duration"}, value}), do: {field, String.to_integer(value)}
   defp parse_datatypes({{field, "long"}, value}), do: {field, String.to_integer(value)}
   defp parse_datatypes({{field, "unsignedLong"}, value}), do: {field, String.to_integer(value)}

--- a/test/instream/decoder/csv_test.exs
+++ b/test/instream/decoder/csv_test.exs
@@ -435,6 +435,7 @@ defmodule Instream.Decoder.LineTest do
       #datatype,string,double\r
       type,value\r
       double,10.20\r
+      double,10\r
       double,+Inf\r
       double,-Inf\r
       double,\r
@@ -444,6 +445,10 @@ defmodule Instream.Decoder.LineTest do
                %{
                  "type" => "double",
                  "value" => 10.20
+               },
+               %{
+                 "type" => "double",
+                 "value" => 10.0
                },
                %{
                  "type" => "double",


### PR DESCRIPTION
InfluxDB can send double type values without a decimal point.
To handle this, use `Float.parse/1` instead of `String.to_float/1`.