### PR TITLE
Fix multiple line breaks in response

### DIFF
--- a/lib/instream/decoder/csv.ex
+++ b/lib/instream/decoder/csv.ex
@@ -121,7 +121,7 @@ defmodule Instream.Decoder.CSV do
       "" ->
         []
 
-      _ ->
+      table ->
         table
         |> __MODULE__.Parser.parse_string(skip_headers: false)
         |> parse_annotations(%{datatypes: [], defaults: [], groups: [], table: []})

--- a/test/instream/decoder/csv_test.exs
+++ b/test/instream/decoder/csv_test.exs
@@ -332,6 +332,34 @@ defmodule Instream.Decoder.LineTest do
 
       assert [] = CSV.parse(response)
     end
+
+    test "response with multiple line break" do
+      response = """
+      #datatype,string,long\r
+      type,value\r
+      long,1\r
+      \r
+      \r
+      #datatype,string,long\r
+      type,value\r
+      long,2\r
+      """
+
+      assert [
+               [
+                 %{
+                   "type" => "long",
+                   "value" => 1
+                 }
+               ],
+               [
+                 %{
+                   "type" => "long",
+                   "value" => 2
+                 }
+               ]
+             ] = CSV.parse(response)
+    end
   end
 
   describe "datatype mapping" do


### PR DESCRIPTION
Hi, we just got a situation that influxdb2 may respond with multiple line breaks between two tables.

Example response data:
```
#datatype,string,long,string,double\r\n#default,integral,,,\r\n#group,false,false,true,false\r\n,result,table,_measurement,charge_energy_used\r\n,,0,charges,75.89999999999999\r\n\r\n\r\n#datatype,string,long,string,double\r\n#default,spread,,,\r\n#group,false,false,true,false\r\n,result,table,_measurement,charge_energy_added\r\n,,0,charges,0.31\r\n\r\n#datatype,string,long,string,long,double,double\r\n#default,first,,,,,\r\n#group,false,false,true,false,false,false\r\n,result,table,_measurement,start_battery_level,start_ideal_range_km,start_rated_range_km\r\n,,0,charges,50,266.6,206.6\r\n\r\n#datatype,string,long,string,long,double,double\r\n#default,last,,,,,\r\n#group,false,false,true,false,false,false\r\n,result,table,_measurement,end_battery_level,end_ideal_range_km,end_rated_range_km\r\n,,0,charges,54,268.6,208.6\r\n\r\n#datatype,string,long,string,double\r\n#default,avg,,,\r\n#group,false,false,true,false\r\n,result,table,_measurement,outside_temp_avg\r\n,,0,charges,15.25\r\n\r\n
```