### PR TITLE
Fix spec of write/3 of Instream.Connection.{QueryRunnerV1, QueryRunnnerV2}

### DIFF
--- a/lib/instream/connection/query_runner_v1.ex
+++ b/lib/instream/connection/query_runner_v1.ex
@@ -161,7 +161,7 @@ defmodule Instream.Connection.QueryRunnerV1 do
   @doc """
   Executes `:write` queries.
   """
-  @spec write([map], Keyword.t(), map) :: any
+  @spec write([map], Keyword.t(), module) :: any
   def write(points, opts, conn) do
     config = conn.config()
 

--- a/lib/instream/connection/query_runner_v2.ex
+++ b/lib/instream/connection/query_runner_v2.ex
@@ -118,7 +118,7 @@ defmodule Instream.Connection.QueryRunnerV2 do
   @doc """
   Executes `:write` queries.
   """
-  @spec write([map], Keyword.t(), map) :: any
+  @spec write([map], Keyword.t(), module) :: any
   def write(points, opts, conn) do
     config = conn.config()
 


### PR DESCRIPTION
Following `Instream.Connection`, `write/3` of `Instream.Connection.{QueryRunnerV1, QueryRunnnerV2}` take its 3rd param as `module` not `map`.

```elixir
      @impl Connection
      def write(points, opts \\ [])

      def write(point, opts) when is_map(point), do: write([point], opts)

      def write(points, opts) when is_list(points) do
        case config(:version) do
          :v2 -> QueryRunnerV2.write(points, opts, __MODULE__)
          _ -> QueryRunnerV1.write(points, opts, __MODULE__)
        end
      end
```