### PR TITLE
Fix (default) query language header for InfluxDB v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
     - Configuration access for a connection now returns the configured `:otp_app` used (`nil` if none)
     - Starting a connection will now issue a warning if the configured `:otp_app` contains no configuration
 
+- Bug fixes
+    - Read queries now send the proper `Content-Type: application/json` header for InfluxDB v2.x connections without having to explicitly pass `query_language: :flux` as an option ([#76](https://github.com/mneudert/instream/issues/76))
+
 ## v2.1.0 (2022-08-02)
 
 - Enhancements

--- a/lib/instream/query/headers.ex
+++ b/lib/instream/query/headers.ex
@@ -86,21 +86,27 @@ defmodule Instream.Query.Headers do
       iex> assemble_language(:v1, :flux)
       [{"Accept", "application/csv"}, {"Content-Type", "application/vnd.flux"}]
 
-      iex> assemble_language(:v2, :influxql)
-      [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+      iex> assemble_language(:v1, :influxql)
+      []
+
+      iex> assemble_language(:v2, nil)
+      [{"Accept", "application/csv"}, {"Content-Type", "application/json"}]
 
       iex> assemble_language(:v2, :flux)
       [{"Accept", "application/csv"}, {"Content-Type", "application/json"}]
+
+      iex> assemble_language(:v2, :influxql)
+      [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
   """
   @spec assemble_language(:v1 | :v2, nil | :flux | :influxql) :: [{String.t(), String.t()}]
   def assemble_language(:v1, :flux),
     do: [{"Accept", "application/csv"}, {"Content-Type", "application/vnd.flux"}]
 
-  def assemble_language(:v2, :flux),
-    do: [{"Accept", "application/csv"}, {"Content-Type", "application/json"}]
-
   def assemble_language(:v2, :influxql),
     do: [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+
+  def assemble_language(:v2, _),
+    do: [{"Accept", "application/csv"}, {"Content-Type", "application/json"}]
 
   def assemble_language(_, _), do: []
 


### PR DESCRIPTION
Adds the missing `Content-Type: application/json` header for Flux queries (without explicit `:query_language`) when talking to InfluxDB v2.x.

This should fix #76.