### PR TITLE
Fix the pool_timeout param usage

### DIFF
--- a/lib/instream/writer/udp.ex
+++ b/lib/instream/writer/udp.ex
@@ -58,7 +58,7 @@ defmodule Instream.Writer.UDP do
     pool_name = Module.concat(conn, UDPWriterPool)
     pool_timeout = opts[:pool_timeout] || default_pool_timeout
 
-    worker = :poolboy.checkout(pool_name, pool_timeout)
+    worker = :poolboy.checkout(pool_name, true, pool_timeout)
 
     :ok =
       if opts[:async] do


### PR DESCRIPTION
This MR fix the `pool_timeout` parameter  usage  from a config. 

 `poolboy:checkout` function has arity 2/3 there the second argument is not a timeout.
The second  argument allows to block and wait a free worker. 