### PR TITLE
Fix logger warning

### DIFF
--- a/lib/instream/connection/config.ex
+++ b/lib/instream/connection/config.ex
@@ -326,7 +326,7 @@ defmodule Instream.Connection.Config do
       with otp_app when not is_nil(otp_app) <- conn.config(:otp_app),
            nil <- Application.get_env(otp_app, conn) do
         _ =
-          Logger.warn("""
+          Logger.warning("""
           Instream connection #{inspect(conn)} is configured to fetch its
           configuration from the application #{inspect(otp_app)} but the
           configuration is empty.


### PR DESCRIPTION
In newer versions of Elixir using `Logger.warn` ironically causes a warning when compiling.

![Screenshot 2024-12-04 at 11 05 02](https://github.com/user-attachments/assets/8a5cf3ea-bb12-4a5f-b093-2e29e9df36f3)
